### PR TITLE
Allow execute msbuild.exe to build projects from WSL

### DIFF
--- a/msbuild.sh
+++ b/msbuild.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+PATH="/mnt/c/Windows/System32/:/mnt/c/Program Files (x86)/Microsoft Visual Studio/2017/Community/MSBuild/15.0/Bin/:${PATH}"
+msbuild.exe $@


### PR DESCRIPTION
允许 WSL 用户从 Bash on Windows 构建项目，依赖 #20 