### PR TITLE
版面美化

### DIFF
--- a/CharacterFloatInfo/CharacterFloatInfo.cs
+++ b/CharacterFloatInfo/CharacterFloatInfo.cs
@@ -1,6 +1,7 @@
 using Harmony12;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using UnityEngine;
 using UnityEngine.UI;
@@ -65,7 +66,7 @@ namespace CharacterFloatInfo
             //GUILayout.BeginHorizontal();
             Main.settings.enableTalkShortMode = GUILayout.Toggle(Main.settings.enableTalkShortMode, "在对话界面只显示部分信息", new GUILayoutOption[0]);
             Main.settings.enableListShortMode = GUILayout.Toggle(Main.settings.enableListShortMode, "在分配工作界面只显示部分信息", new GUILayoutOption[0]);
-            Main.settings.addonInfo = GUILayout.Toggle(Main.settings.addonInfo, "显示原始信息", new GUILayoutOption[0]);
+            Main.settings.addonInfo = GUILayout.Toggle(Main.settings.addonInfo, "显示原始信息的差異", new GUILayoutOption[0]);
             Main.settings.showBest = GUILayout.Toggle(Main.settings.showBest, "显示最佳物品与功法", new GUILayoutOption[0]);
             Main.settings.lifeMessage = GUILayout.Toggle(Main.settings.lifeMessage, "显示人物经历", new GUILayoutOption[0]);
             Main.settings.showCharacteristic = GUILayout.Toggle(Main.settings.showCharacteristic, "显示人物特性", new GUILayoutOption[0]);
@@ -167,18 +168,21 @@ namespace CharacterFloatInfo
             BuildingWindow
         };
         public static WindowType windowType = WindowType.MapActorList;
-        public static void Postfix(bool on, GameObject tips, ref Text ___itemMoneyText, ref Text ___itemLevelText, ref Text ___informationMassage, ref Text ___informationName, ref bool ___anTips, ref GameObject ___informationWindow, ref int ___tipsW, ref int ___tipsH)
+        public static void Postfix(bool on, GameObject tips, ref Text ___itemMoneyText, ref Text ___itemLevelText, ref Text ___informationMassage, ref Text ___informationName, ref bool ___anTips, ref GameObject ___informationWindow, ref int ___tipsW)
         {
             if (!Main.enabled) return;
             if (___informationWindow == null || ___informationWindow.transform == null || ActorMenu.instance == null) return; //未入GAME
             actorFeatureHolder = ___informationWindow.transform.Find("actorFeatureHolder");
             if (actorFeatureHolder == null)
             {
-                actorFeatureHolder = UnityEngine.Object.Instantiate<GameObject>(ActorMenu.instance.actorFeatureHolder.gameObject, new Vector3(20f, -170f, 0), Quaternion.identity).transform;
-                actorFeatureHolder.SetParent(___informationWindow.transform, false);
+                //actorFeatureHolder = new GameObject().transform;
+                actorFeatureHolder = UnityEngine.Object.Instantiate<GameObject>(ActorMenu.instance.actorFeatureHolder.gameObject, new Vector3(22f, -125f, 1), Quaternion.identity).transform;
                 actorFeatureHolder.name = "actorFeatureHolder";
-                actorFeatureHolder.localScale = new Vector3(.65f, .65f, .65f);
-                actorFeatureHolder.GetComponent<RectTransform>().sizeDelta = new Vector2(338f, 200f);
+                actorFeatureHolder.SetParent(___informationWindow.transform, false);
+                actorFeatureHolder.localScale = new Vector3(.73f, .73f, 1);
+                actorFeatureHolder.GetComponent<RectTransform>().sizeDelta = new Vector2(800f, 0);
+                ___itemLevelText.GetComponent<RectTransform>().sizeDelta = new Vector2(150, 0);
+                ___itemMoneyText.GetComponent<RectTransform>().sizeDelta = new Vector2(150, 0);
             }
             else if (actorFeatureHolder.childCount > 0)
             {
@@ -192,6 +196,7 @@ namespace CharacterFloatInfo
             {
                 bool needShow = false;
                 int id = -1;
+
                 //建筑/地图左边的列表
                 string[] array = tips.name.Split(',');
                 if (array[0] == "Actor")
@@ -209,7 +214,9 @@ namespace CharacterFloatInfo
                         needShow = true;
                         windowType = WindowType.BuildingWindow;
                     }
+
                 }
+
                 //对话窗口的人物头像
                 else if (array[0] == "FaceHolder" && Main.settings.talkMessage)
                 {
@@ -220,10 +227,12 @@ namespace CharacterFloatInfo
 
                 if (needShow)
                 {
+                    ___tipsW = 680;
                     ___itemLevelText.text = SetLevelText(id);
                     ___itemMoneyText.text = SetMoneyText(id);
+                    //___itemMoneyText.text = ___itemMoneyText.GetComponent<RectTransform>().sizeDelta.x.ToString() +"x"+ ___itemMoneyText.GetComponent<RectTransform>().sizeDelta.y.ToString();
                     ___informationName.text = SetInfoName(id);
-                    ___informationMassage.text = SetInfoMassage(id, ___informationWindow);
+                    ___informationMassage.text = SetInfoMessage(id, ref ___tipsW);
                     ___anTips = true;
                 }
             }
@@ -232,13 +241,13 @@ namespace CharacterFloatInfo
         //标题栏左侧小字号文本
         public static string SetLevelText(int id)
         {
-            return string.Format("\t{0}({1})", GetAge(id), GetHealth(id));
+            return string.Format("岁数: {0}\n寿命: {1}", GetAge(id), GetHealth(id));
         }
 
         //标题栏右侧侧小字号文本
         public static string SetMoneyText(int id)
         {
-            return GetChame(id, Main.settings.addonInfo);
+            return GetActorGang(id) + GetGangLevelColorText(id) + "\n" + GetChame(id);
         }
 
         //标题栏
@@ -250,7 +259,7 @@ namespace CharacterFloatInfo
             string samsaraNmae = GetSamsaraName(id);
             text += samsaraNmae.Length > 0 ? " ◆ " + samsaraNmae : "";
             text += "\n" + GetMood(id) + " • " + GetFame(id);
-            if (age > 14) //低于14岁不显示婚姻状况
+            if (age > ConstValue.actorMinAge) //低于14岁不显示婚姻状况
             {
                 text += " • " + GetSpouse(id);
             }
@@ -300,34 +309,45 @@ namespace CharacterFloatInfo
                     text += DateFile.instance.SetColoer(20004, "\n健康");
                     break;
             }
-            //text += "\n烈毒" + list1[0] + "/郁毒" + list1[1] + "/寒毒" + list1[2] + "/赤毒" + list1[3] + "/腐毒" + list1[4] + "/幻毒" + list1[5];
+
             return text;
         }
 
         //文本
-        public static string SetInfoMassage(int id, GameObject ___informationWindow)
+        public static string SetInfoMessage(int id, ref int ___tipsW)
+        {
+            return SetInfoMessage1(id) + "\n" + SetInfoMessage2(id, ref ___tipsW) + SetInfoMessage3(id) + SetInfoMessage4(id) + SetInfoMessage5(id);
+        }
+
+        public static string SetInfoMessage1(int id)
         {
             string text = "";
             if (windowType == WindowType.Dialog && Main.settings.enableTalkShortMode)
                 return text;
             if (windowType == WindowType.BuildingWindow && Main.settings.enableListShortMode)
                 return text;
-            text += "\t立场：" + GetGoodness(id) + "\t\t\t轮回：" + GetSamsara(id) + "次";
-            if (GetAge(id) > 14)
+            text += "立场：" + GetGoodness(id) + "\t\t\t轮回：" + GetSamsara(id) + "次";
+            if (GetAge(id) > ConstValue.actorMinAge)
             {
                 text += "\t\t\t子嗣：" + DateFile.instance.GetActorSocial(id, 310, false).Count;
             }
 
-            text += "\n\n\t喜好：" + Gethobby(id, 0);
-            text += "\t\t\t厌恶：" + Gethobby(id, 1) + "\n\n";
+            text += "\t\t\t喜好：" + Gethobby(id, 0);
+            text += "\t\t\t厌恶：" + Gethobby(id, 1);
+            return text;
+        }
 
+        // 個人特性
+        public static string SetInfoMessage2(int id, ref int ___tipsW)
+        {
+            string text = "";
             if (Main.settings.showCharacteristic)
             {
-                text += "\n\n";
+                text += "\n\n\n";
                 List<int> featureIDs = DateFile.instance.GetActorFeature(id);
                 int shown = 0;
                 foreach (int featureID in featureIDs)
-                    if (DateFile.instance.actorFeaturesDate[featureID][95] != "1" || Main.settings.showIV) //判斷是否隱藏的裏特性
+                    if (DateFile.instance.actorFeaturesDate[featureID][95] != "1" || Main.settings.showIV) //判斷是否顯示隱藏的特性
                     {
                         shown++;
                         GameObject actorFeature = UnityEngine.Object.Instantiate<GameObject>(ActorMenu.instance.actorFeature, Vector3.zero, Quaternion.identity);
@@ -371,33 +391,58 @@ namespace CharacterFloatInfo
                         }
 
                     }
-                if (shown > 6) text += "\n\n\n";
-            }
-
-            for (int i = 0; i < 16; i++)
-            {
-                if (i < 14)
-                {
-                    text += string.Format("\t{0}\t\t{1}\n", GetLevel(id, i, 0, Main.settings.addonInfo), GetLevel(id, i, 1, Main.settings.addonInfo));
-                }
-                else
-                {
-                    text += string.Format("\t{0}\n", GetLevel(id, i, 0, Main.settings.addonInfo));
-                }
-            }
-            if(Main.settings.showBest)
-            {
-                text += GetBestItems(id);
-                text += GetBestGongfa(id);
-            }
-
-            if (Main.settings.lifeMessage && windowType == WindowType.MapActorList)//只在大地图显示经历
-            {
-                text += GetLifeMessage(id, 3);
+                if (shown > 7) ___tipsW += (shown - 7) * 90;
             }
             return text;
         }
 
+        // 才能
+        public static string SetInfoMessage3(int id)
+        {
+            string text = "\n";
+            foreach (int i in DateFile.instance.baseSkillDate.Keys) {
+                var canStudy =
+                text += CanTeach(id, i) ? "※" : "　";
+                text += GetLevel(id, i, Main.settings.addonInfo);
+                text += i % 4 == (i < 100 ? 3 : 0) ? "\n" : "\t\t";
+                if (i == 15) text += "\n";
+            }
+            return text + "\n";
+        }
+        // 根據NPC的門派或職業,配斷能否傳授你這生活藝能
+        public static bool CanTeach(int id, int i)
+        {
+            bool result = false;
+            // todo 
+            // 下九流38教12,13,14,15; 手艺人37教6,7,10,11; 大夫36教8,9; 文人34教0,1,2,3,4,5
+            // 少林??教??;
+
+            return result;
+        }
+
+        // 最佳 裝備 & 物品 & 武功
+        public static string SetInfoMessage4(int id)
+        {
+            string text = "";
+            if (Main.settings.showBest)
+            {
+                text += "\n" + GetEquipments(id);
+                text += "\n" + GetBestItems(id);
+                text += "\n" + GetBestGongfa(id);
+            }
+            return text;
+        }
+
+        // 近期事件
+        public static string SetInfoMessage5(int id)
+        {
+            string text = "";
+            if (Main.settings.lifeMessage && windowType == WindowType.MapActorList)//只在大地图显示经历
+            {
+                text += "\n" + GetLifeMessage(id, 3) + "\n";
+            }
+            return text;
+        }
 
         //心情
         public static string GetMood(int id)
@@ -406,39 +451,20 @@ namespace CharacterFloatInfo
         }
 
         //魅力
-        public static string GetChame(int id, bool shownoadd)
+        public static string GetChame(int id)
         {
-            // 显示未加成数据 true
-            string text = ((int.Parse(DateFile.instance.GetActorDate(id, 11, false)) > 14 || !Main.settings.hideChameOfChildren)
-                ? ((int.Parse(DateFile.instance.GetActorDate(id, 8, false)) != 1 || int.Parse(DateFile.instance.GetActorDate(id, 305, false)) != 0)
-                    ? DateFile.instance.massageDate[25][int.Parse(DateFile.instance.GetActorDate(id, 14, false)) - 1].Split(new char[]
-                    {
-                        '|'
-                    })[Mathf.Clamp(int.Parse(DateFile.instance.GetActorDate(id, 15, true)) / 100, 0, 9)]
-                    : DateFile.instance.massageDate[25][5].Split(new char[]
-                    {
-                        '|'
-                    })[1])
-                : DateFile.instance.massageDate[25][5].Split(new char[]
-                {
-                    '|'
-                })[0]);
-            if (shownoadd)
-            {
-                text += "（" + ((int.Parse(DateFile.instance.GetActorDate(id, 11, false)) > 14 || !Main.settings.hideChameOfChildren)
-                            ? ((int.Parse(DateFile.instance.GetActorDate(id, 8, false)) != 1 || int.Parse(DateFile.instance.GetActorDate(id, 305, false)) != 0)
-                                ? DateFile.instance.massageDate[25][int.Parse(DateFile.instance.GetActorDate(id, 14, false)) - 1].Split(new char[]
-                                {
-                                    '|'
-                                })[Mathf.Clamp(int.Parse(DateFile.instance.GetActorDate(id, 15, false)) / 100, 0, 9)]
-                                : DateFile.instance.massageDate[25][5].Split(new char[]
-                                {
-                                    '|'
-                                })[1])
-                            : DateFile.instance.massageDate[25][5].Split(new char[]
-                            {
-                                '|'
-                            })[0]) + "）";
+            int actorChame = Mathf.Clamp(int.Parse(DateFile.instance.GetActorDate(id, 15, true)) / 100, 0, 9);
+            int actorChameDiff = int.Parse(DateFile.instance.GetActorDate(id, 15, true)) - int.Parse(DateFile.instance.GetActorDate(id, 15, false));
+            bool isChild = int.Parse(DateFile.instance.GetActorDate(id, 11, false)) <= ConstValue.actorMinAge;
+            bool hasWearing = int.Parse(DateFile.instance.GetActorDate(id, 8, false)) != 1 || int.Parse(DateFile.instance.GetActorDate(id, 305, false)) != 0;
+            string text = isChild && Main.settings.hideChameOfChildren ?
+                DateFile.instance.massageDate[25][5].Split('|')[0] : (hasWearing ?
+                    DateFile.instance.massageDate[25][int.Parse(DateFile.instance.GetActorDate(id, 14, false)) - 1].Split('|')[actorChame] :
+                    DateFile.instance.massageDate[25][5].Split('|')[1]
+                );
+            if (Main.settings.addonInfo && !isChild && actorChameDiff != 0)
+            { // 显示未加成数据 true
+                text += " <color=#606060FF>" + (actorChameDiff > 0 ? "+" : "") + actorChameDiff + "</color>";
             }
 
             return text;
@@ -454,10 +480,7 @@ namespace CharacterFloatInfo
         //立场
         public static string GetGoodness(int id)
         {
-            string text = DateFile.instance.massageDate[9][0].Split(new char[]
-            {
-                '|'
-            })[DateFile.instance.GetActorGoodness(id)];
+            string text = DateFile.instance.massageDate[9][0].Split('|')[DateFile.instance.GetActorGoodness(id)];
             return text;
         }
 
@@ -467,10 +490,7 @@ namespace CharacterFloatInfo
             //喜欢 0 讨厌 1
             string text = ((int.Parse(DateFile.instance.GetActorDate(id, 207 + hobby, false)) != 1)
                 ? DateFile.instance.massageDate[301][1]
-                : DateFile.instance.massageDate[301][0].Split(new char[]
-                {
-                    '|'
-                })[int.Parse(DateFile.instance.GetActorDate(id, 202 + hobby, false))]);
+                : DateFile.instance.massageDate[301][0].Split('|')[int.Parse(DateFile.instance.GetActorDate(id, 202 + hobby, false))]);
             if (text.Length < 2)
             {
                 text += "\t";
@@ -480,41 +500,17 @@ namespace CharacterFloatInfo
         }
 
         //资质
-        public static string GetLevel(int id, int index, int gongfa, bool shownoadd)
+        public static string GetLevel(int id, int index, bool shownoadd)
         {
-            // 生活技能 0 战斗技能 1
-            //显示未加成数据 true
             int colorCorrect = Main.settings.useColorOfTeachingSkill ? 40 : 20;
-            int num = int.Parse(DateFile.instance.GetActorDate(id, 501 + index + 100 * gongfa, true));
-            int num2 = int.Parse(DateFile.instance.GetActorDate(id, 501 + index + 100 * gongfa, false));
-            string text = DateFile.instance.SetColoer(20002 + Mathf.Clamp((num - colorCorrect) / 10, 0, 8), string.Concat(new object[]
-            {
-                DateFile.instance.baseSkillDate[index + 101 * gongfa][0],
-                DateFile.instance.massageDate[7003][4].Split(new char[]
-                {
-                    '|'
-                })[2],
-                WindowManage.instance.Mut(),
-                num
-            }), false);
-            text += num < 10 ? "\t\t" : num < 100 ? "\t" : "";
-            if (shownoadd)
-            {
-                if (num != num2)
-                {
-                    text += "« \t" + DateFile.instance.SetColoer(20002 + Mathf.Clamp((num - colorCorrect) / 10, 0, 8), num2.ToString());
-                    text += num2 < 10 ? "\t\t" : num2 < 100 ? "\t" : "";
-                }
-                else
-                {
-                    text += "\t\t\t";
-                }
-            }
-            else
-            {
-                text += "\t\t";
-            }
-
+            int num = int.Parse(DateFile.instance.GetActorDate(id, 501 + index, true));
+            int num2 = num - int.Parse(DateFile.instance.GetActorDate(id, 501 + index, false));
+            shownoadd = shownoadd && num2 != 0;
+            string text = DateFile.instance.SetColoer(20002 + Mathf.Clamp((num - colorCorrect) / 10, 0, 8),
+                string.Format("{0}{1,3}{2}<color=#606060ff>{3,3}</color>{4}",
+                    DateFile.instance.baseSkillDate[index][0],
+                    num.ToString(), (num < 10 ? " " : "") + (num < 100 ? "  " : ""),
+                    shownoadd ? (num2 < 0 ? "" : "+") + num2.ToString() : "    ", shownoadd && Math.Abs(num2) < 10 ? " " : ""));
             return text;
         }
 
@@ -530,8 +526,14 @@ namespace CharacterFloatInfo
         {
             int health = ActorMenu.instance.Health(id);
             int maxhealth = ActorMenu.instance.MaxHealth(id);
-            string peopleHealthText = string.Format("{0}{1}</color> / {2}", ActorMenu.instance.Color3(health, maxhealth), health, maxhealth);
-            return peopleHealthText;
+            // string peopleHealthText = string.Format("{0}{1}</color> / {2}", ActorMenu.instance.Color3(health, maxhealth), health, maxhealth);
+            int totalAge = GetAge(id) + maxhealth;
+            int ageReduced = health - maxhealth;
+            int ageGrade = Mathf.Clamp((int)Math.Floor((decimal)totalAge / 10), 0, 8);
+            return string.Format("{0}<color=red>{1}</color>",
+                DateFile.instance.SetColoer(20001 + ageGrade, totalAge.ToString()),
+                ageReduced != 0 ? ageReduced.ToString() : ""
+                );
         }
 
         //红蓝条
@@ -555,12 +557,12 @@ namespace CharacterFloatInfo
         public static List<int> GetPoison(int id)
         {
 
-            List<int> list = new List<int> {};
+            List<int> list = new List<int> { };
 
             for (int i = 0; i < 6; i++)
             {
                 int num = int.Parse(DateFile.instance.GetActorDate(id, 51 + i, false));
-       
+
                 list.Add(num);
             }
 
@@ -616,6 +618,15 @@ namespace CharacterFloatInfo
             return text;
         }
 
+        // 所屬地
+        public static string GetActorGang(int key)
+        {
+            string text = "";
+            int num = int.Parse(DateFile.instance.GetActorDate(key, 19, false));
+            text += DateFile.instance.GetGangDate(num, 0);
+            return text;
+        }
+
         //人物在组织中等级ID
         public static int GetGangLevelId(int id)
         {
@@ -624,6 +635,7 @@ namespace CharacterFloatInfo
             int gangValueId = DateFile.instance.GetGangValueId(num2, num3);
             return gangValueId;
         }
+
         //人物在组织中等级名称
         public static string GetGangLevelText(int id)
         {
@@ -634,6 +646,32 @@ namespace CharacterFloatInfo
             string gang = DateFile.instance.presetGangGroupDateValue[gangValueId][key2];
             return gang;
         }
+
+        public static string GetGangLevelColorText(int id)
+        {
+            int grade = Mathf.Abs(int.Parse(DateFile.instance.GetActorDate(id, 20, false)));
+            return DateFile.instance.SetColoer(20011 - grade, GetGangLevelText(id));
+        }
+
+        //人物身上裝備
+        public static string GetEquipments(int id)
+        {
+            List<string> autorEquipments = new List<string>{};
+            //List<int> itemSort = DateFile.instance.GetItemSort(new List<int>(ActorMenu.instance.GetActorItems(id, 4).Keys));
+            //            Dictionary<int, int> itemSort = ActorMenu.instance.GetActorItems(id, 4);
+            // List<int> list = new List<int>(ActorMenu.instance.GetActorItems(id, 4).Keys);
+            for (int i = 301; i <= 310; i++)
+            {
+                int itemID = int.Parse(DateFile.instance.GetActorDate(id, i, false));
+                if (itemID != 0){
+                    autorEquipments.Add(GetItemColorName(itemID));
+                }
+            }
+            return "人物裝備: " + (autorEquipments.Count() == 0 ? 
+                DateFile.instance.SetColoer(20002, GetGenderTA(id) + "赤身裸体在你眼前") : 
+                string.Join(" / ", autorEquipments.ToArray())) + "\n";
+        }
+
         //人物身上最高级功法获取
         public static string GetBestGongfa(int id)
         {
@@ -641,7 +679,7 @@ namespace CharacterFloatInfo
             List<int> gongFas = new List<int>(DateFile.instance.actorGongFas[id].Keys);
             if (gongFas.Count == 0)
             {
-                return "\n\t最佳功法: 他还没来得及学";
+                return "最佳功法: 他还没来得及学";
             }
             string bestName = "";
             int bestLevel = 0;
@@ -660,66 +698,42 @@ namespace CharacterFloatInfo
                 }
                 else
                 {
-                    if(intLevel == bestLevel)
+                    if (intLevel == bestLevel)
                     {
+                        bestName += " / " + gongFaName;
                         count += 1;
                     }
                 }
-               // Main.Logger.Log(string.Format("gongfas-{0}-{1}-{2}-{3}", i, gongFaId, gongFaName,level));
             }
-            //Main.Logger.Log(string.Format("gongfas-final-{0}-{1}", bestLevel,bestName));
-            bestName = DateFile.instance.SetColoer(20001 + bestLevel, bestName);
-            string after = "";
-            if (count > 1)
-            {
-                after = " 等" + count + "种."; 
-            }
-      
-            return "\n\t最佳功法: " + bestName + after;
+            return "最佳功法: " + DateFile.instance.SetColoer(20001 + bestLevel, bestName) + "\n";
         }
 
         //人物身上的最佳物品获取
         public static string GetBestItems(int id)
         {
+            List<string> bestItems = new List<string> { };
+            int bestGrade = 0;
+
             List<int> list = new List<int>(ActorMenu.instance.GetActorItems(id, 0).Keys);
-            if (list.Count == 0)
+            foreach (int itemID in list)
             {
-                return "\n\t最佳物品: 这是个穷光蛋";
-            }
-            string bestName = "";
-            int bestLevel = 0;
-            int count = 1;
-            for (int i = 0; i < list.Count; i++)
-            {
-                int itemId = list[i];
-                string itemName = DateFile.instance.GetItemDate(itemId, 0, true);
-                string level = DateFile.instance.GetItemDate(itemId, 8, true);
-                int intLevel = int.Parse(level);
-                if (intLevel > bestLevel)
+                string itemName = GetItemColorName(itemID);
+                int itemGrade = int.Parse(DateFile.instance.GetItemDate(itemID, 8, false));
+                if (itemGrade > bestGrade)
                 {
-                    bestLevel = intLevel;
-                    bestName = itemName;
-                    count = 1;
+                    bestGrade = itemGrade;
+                    bestItems = new List<string> { itemName };
                 }
-                else
+                else if (itemGrade == bestGrade)
                 {
-                    if (intLevel == bestLevel)
-                    {
-                        count += 1;
+                    if (!bestItems.ToList().Contains(itemName)) {
+                        bestItems.Add(itemName);
                     }
                 }
             }
-            //获得的物品名格式为xx\n下九品，需去掉后缀，改用颜色进行标识。
-            int index = bestName.IndexOf("\n");
-            bestName = bestName.Substring(0, index);
-            bestName = DateFile.instance.SetColoer(20001 + bestLevel, bestName);
-            string after = "";
-            if (count > 1)
-            {
-                after = " 等" + count + "种.";
-            }
-
-            return "\n\t最佳物品: " + bestName + after;
+            return "最佳物品: " + (bestItems.Count() == 0 ?
+                DateFile.instance.SetColoer(20002, GetGenderTA(id) + "是个穷光蛋") :
+                string.Join(" / ", bestItems.ToArray())) + "\t" + GetItemWeight(id) + "\n";
         }
 
         //村民工作地点
@@ -820,22 +834,13 @@ namespace CharacterFloatInfo
             {
                 actorMassage.Clear();
                 int num = DateFile.instance.MianActorID();
-                actorMassage.Add(string.Format("\n{0}{1}{2}{3}{4}\n", new object[]
+                actorMassage.Add(string.Format("{0}{1}{2}{3}{4}", new object[]
                 {
-                    DateFile.instance.massageDate[8010][1].Split(new char[]
-                    {
-                        '|'
-                    })[0],
+                    DateFile.instance.massageDate[8010][1].Split('|')[0],
                     DateFile.instance.SetColoer(10002, DateFile.instance.solarTermsDate[int.Parse(DateFile.instance.GetActorDate(id, 25, false))][102], false),
-                    DateFile.instance.massageDate[8010][1].Split(new char[]
-                    {
-                        '|'
-                    })[1],
+                    DateFile.instance.massageDate[8010][1].Split('|')[1],
                     DateFile.instance.GetActorName(id, false, true),
-                    DateFile.instance.massageDate[8010][1].Split(new char[]
-                    {
-                        '|'
-                    })[2]
+                    DateFile.instance.massageDate[8010][1].Split('|')[2]
                 }));
                 if (DateFile.instance.actorLifeMassage.ContainsKey(id))
                 {
@@ -845,21 +850,15 @@ namespace CharacterFloatInfo
                     {
                         int[] array = DateFile.instance.actorLifeMassage[id][i];
                         int key2 = array[0];
-                        string[] array2 = DateFile.instance.actorMassageDate[key2][2].Split(new char[]
-                        {
-                            '|'
-                        });
-                        string[] array3 = DateFile.instance.actorMassageDate[key2][99].Split(new char[]
-                        {
-                            '|'
-                        });
+                        string[] array2 = DateFile.instance.actorMassageDate[key2][2].Split('|');
+                        string[] array3 = DateFile.instance.actorMassageDate[key2][99].Split('|');
                         List<string> list = new List<string>
                         {
                             DateFile.instance.massageDate[16][1] + DateFile.instance.SetColoer(10002, array[1].ToString(), false) + DateFile.instance.massageDate[16][3],
                             DateFile.instance.SetColoer(20002, DateFile.instance.solarTermsDate[array[2]][0], false)
                         };
 
-                        list.Add(DateFile.instance.SetColoer(10001, DateFile.instance.GetNewMapDate(array[3], array[4], 98) + DateFile.instance.GetNewMapDate(array[3], array[4], 0), false));
+                        list.Add(DateFile.instance.SetColoer(10004, DateFile.instance.GetNewMapDate(array[3], array[4], 98) + DateFile.instance.GetNewMapDate(array[3], array[4], 0), false));
                         for (int j = 0; j < array3.Length; j++)
                         {
                             list.Add(array3[j]);
@@ -874,22 +873,10 @@ namespace CharacterFloatInfo
                                     list.Add(DateFile.instance.SetColoer((int.Parse(DateFile.instance.GetActorDate(num2, 26, false)) <= 0) ? 10002 : 20010, DateFile.instance.GetActorName(num2, false, false), false));
                                     break;
                                 case 1:
-                                    list.Add(DateFile.instance.massageDate[10][0].Split(new char[]
-                                    {
-                                        '|'
-                                    })[0] + DateFile.instance.SetColoer(20001 + int.Parse(DateFile.instance.GetItemDate(num2, 8, true)), DateFile.instance.GetItemDate(num2, 0, false), false) + DateFile.instance.massageDate[10][0].Split(new char[]
-                                    {
-                                        '|'
-                                    })[1]);
+                                    list.Add(DateFile.instance.massageDate[10][0].Split('|')[0] + DateFile.instance.SetColoer(20001 + int.Parse(DateFile.instance.GetItemDate(num2, 8, true)), DateFile.instance.GetItemDate(num2, 0, false), false) + DateFile.instance.massageDate[10][0].Split('|')[1]);
                                     break;
                                 case 2:
-                                    list.Add(DateFile.instance.SetColoer(20001 + int.Parse(DateFile.instance.gongFaDate[num2][2]), DateFile.instance.massageDate[10][0].Split(new char[]
-                                    {
-                                        '|'
-                                    })[0] + DateFile.instance.gongFaDate[num2][0] + DateFile.instance.massageDate[10][0].Split(new char[]
-                                    {
-                                        '|'
-                                    })[1], false));
+                                    list.Add(DateFile.instance.SetColoer(20001 + int.Parse(DateFile.instance.gongFaDate[num2][2]), DateFile.instance.massageDate[10][0].Split('|')[0] + DateFile.instance.gongFaDate[num2][0] + DateFile.instance.massageDate[10][0].Split('|')[1], false));
                                     break;
                                 case 3:
                                     list.Add(DateFile.instance.SetColoer(20008, DateFile.instance.resourceDate[num2][0], false));
@@ -902,21 +889,15 @@ namespace CharacterFloatInfo
                                     break;
                             }
                         }
-
-                        actorMassage.Add(string.Format(" {0}{1}：" + DateFile.instance.actorMassageDate[key2][1] + "\n", list.ToArray()));
+                        // 避免使用空格,要用 non-break space 字元 (i.e. ALT+SPACE in Mac), 否則unity有機會無故在Space位置加插空行
+                        actorMassage.Add(string.Format("{0}{1}: " + DateFile.instance.actorMassageDate[key2][1] + "\n", list.ToArray()));
                     }
                 }
 
                 int num3 = int.Parse(DateFile.instance.GetActorDate(id, 26, false));
                 if (num3 > 0)
                 {
-                    actorMassage.Add(string.Format("■ {0}{1}{2}\n", DateFile.instance.massageDate[8010][2].Split(new char[]
-                    {
-                        '|'
-                    })[0], DateFile.instance.SetColoer(10002, DateFile.instance.GetActorDate(id, 11, false), false), DateFile.instance.massageDate[8010][2].Split(new char[]
-                    {
-                        '|'
-                    })[1]));
+                    actorMassage.Add(string.Format("■ {0}{1}{2}\n", DateFile.instance.massageDate[8010][2].Split('|')[0], DateFile.instance.SetColoer(10002, DateFile.instance.GetActorDate(id, 11, false), false), DateFile.instance.massageDate[8010][2].Split('|')[1]));
                 }
 
                 lastActorID = id;
@@ -931,6 +912,7 @@ namespace CharacterFloatInfo
 
             return text;
         }
+
         //工作效率,null代表无法获得
         public static string GetWorkingData(int workerId)
         {
@@ -1004,5 +986,50 @@ namespace CharacterFloatInfo
             else
                 return null;
         }
+
+        //人物賦性
+        public static string GetResource(int id)
+        {
+            string result = "";
+            int[] actorResources = ActorMenu.instance.GetActorResources(id);  //401~407
+            for (int i = 0; i < actorResources.Count(); i++)
+            {
+                result += DateFile.instance.SetColoer(20001 + i, DateFile.instance.massageDate[1002][2].Split('|')[i+1] + actorResources[i].ToString());
+            }
+
+            return result;
+        }
+
+
+        // 負重資料
+        public static string GetItemWeight(int key)
+        {
+            string text = "";
+            int maxItemSize = ActorMenu.instance.GetMaxItemSize(key);
+            int useItemSize = ActorMenu.instance.GetUseItemSize(key);
+            text += string.Format("{0}{3}{1} / {2}</color>", new object[] {
+                ActorMenu.instance.Color8(useItemSize, maxItemSize),
+                ((float)useItemSize / 100f).ToString("f1"),
+                ((float)maxItemSize / 100f).ToString("f1"),
+                DateFile.instance.massageDate[807][2].Split('|')[0]
+            });
+            return text;
+        }
+
+        public static string GetGenderTA(int id)
+        {
+            return DateFile.instance.GetActorDate(id, 14, false) == "2" ? "她" : "他";
+        }
+        public static string PurifyItemName(String name)
+        {   //获得的物品名格式为xx\n下九品，需去掉后缀。
+            return name.Split('(')[0].Split('\n')[0];
+        }
+        public static string GetItemColorName(int itemID)
+        {
+            string itemName = PurifyItemName(DateFile.instance.GetItemDate(itemID, 0, false));
+            int itemGrade = int.Parse(DateFile.instance.GetItemDate(itemID, 8, false));
+            return DateFile.instance.SetColoer(20001 + itemGrade, itemName);
+        }
+
     }
 }


### PR DESCRIPTION
1) 版面美化，技藝和能力改為4欄；浮動窗加寬，按個人特性數量加闊。
2) 加入裝備列表，方便玩家抓光NPC的好裝備
3) 列出全部頂級物品、列級功法
4) 原有參數的顯示，改為跟現值的變化度，使看上去更明確。

計劃添加功能： 
顯示人物的七元賦性，方便玩家找同道人； 
標示可向NPC學習的技藝，方便玩家找NPC學技藝。
顯示人物的 好感度 和 警戒心
MOUSE OVER 下面同道人，亦能彈出浮動窗。