### PR TITLE
修复100%效率颜色显示为红色

### DIFF
--- a/HomeShopSort/HomeShopSort.cs
+++ b/HomeShopSort/HomeShopSort.cs
@@ -95,11 +95,11 @@ namespace HomeShopSort
                     {
                         string text = "";
                         int color = 20002 + 6;
-                        int effPct = 100 * eff / total;//当前工作效率
-                        int totalPct = 100 * 200 / total;//最大工作效率
+                        int effPct = 100 * eff / total;                 //当前工作效率
+                        int totalPct = 100 * 200 / total;               //最大工作效率
                         if (Main.settings.showEfficienctUsingDifferentColor)
                         {
-                            int percent = 100 * effPct / totalPct;//占最大效率的百分比
+                            int percent = 100 * effPct / totalPct;      //占最大效率的百分比
                             if (percent >= 90)
                                 color = 20002 + 2;
                             else if (percent >= 70)

--- a/HomeShopSort/HomeShopSort.cs
+++ b/HomeShopSort/HomeShopSort.cs
@@ -95,9 +95,11 @@ namespace HomeShopSort
                     {
                         string text = "";
                         int color = 20002 + 6;
+                        int effPct = 100 * eff / total;//当前工作效率
+                        int totalPct = 100 * 200 / total;//最大工作效率
                         if (Main.settings.showEfficienctUsingDifferentColor)
                         {
-                            int percent = 100 * eff / total;
+                            int percent = 100 * effPct / totalPct;//占最大效率的百分比
                             if (percent >= 90)
                                 color = 20002 + 2;
                             else if (percent >= 70)
@@ -108,7 +110,7 @@ namespace HomeShopSort
                                 color = 20002 + 8;
                         }
                         if (Main.settings.showEfficiencyAsMyWay)
-                            text = "(" + (eff / 2).ToString() + "%)";
+                            text = "(" + (100 * effPct / totalPct).ToString() + "%)";
                         else
                             text = "(" + (100 * eff / total).ToString() + "%)";
                         if (!Main.settings.showEfficienctInBottom)

--- a/genvsproj.cmd
+++ b/genvsproj.cmd
@@ -1,5 +1,5 @@
-set STEAMDIR="C:\\Program Files (x86)\\Steam\\steamapps\\common\\The Scroll Of Taiwu\\"
-::set STEAMDIR="E:\\SteamLibrarys\\steamapps\\common\\The Scroll Of Taiwu\\"
+::set STEAMDIR="C:\\Program Files (x86)\\Steam\\steamapps\\common\\The Scroll Of Taiwu\\"
+set STEAMDIR="E:\\SteamLibrarys\\steamapps\\common\\The Scroll Of Taiwu\\"
 mkdir build
 cd build
 

--- a/genvsproj.cmd
+++ b/genvsproj.cmd
@@ -1,5 +1,5 @@
-::set STEAMDIR="C:\\Program Files (x86)\\Steam\\steamapps\\common\\The Scroll Of Taiwu\\"
-set STEAMDIR="E:\\SteamLibrarys\\steamapps\\common\\The Scroll Of Taiwu\\"
+set STEAMDIR="C:\\Program Files (x86)\\Steam\\steamapps\\common\\The Scroll Of Taiwu\\"
+::set STEAMDIR="E:\\SteamLibrarys\\steamapps\\common\\The Scroll Of Taiwu\\"
 mkdir build
 cd build
 


### PR DESCRIPTION
1、修复颜色显示异常；
2、修复占最大效率百分比计算错误；