### PR TITLE
增加NPCscan功能

### DIFF
--- a/NpcScan/NpcScan.cs
+++ b/NpcScan/NpcScan.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Reflection;
 using Harmony12;
 using UnityEngine;
@@ -25,6 +25,8 @@ namespace NpcScan
         public static Dictionary<int, Features> featuresList = new Dictionary<int, Features>();
         public static List<Features> findList = new List<Features>();
         public static Dictionary<string, int> fNameList = new Dictionary<string, int>();
+        public static List<int> GongFaList = new List<int>();
+        public static Dictionary<string, int> gNameList = new Dictionary<string, int>();
         public static Dictionary<int, string> textColor = new Dictionary<int, string>()
         {
             { 10000,"<color=#323232FF>"},


### PR DESCRIPTION
1.根据功法全名找到会此功法的NPC（多功法需“|”符号分割，功法名需完整）
2.设置查询NPC的最高品级
3.可开启是否识别门派，选择搜索仅门派NPC或非门派NPC
![image](https://s2.ax1x.com/2019/02/03/kGPDkF.png)
![image](https://s2.ax1x.com/2019/02/03/kGPsfJ.png)
![image](https://s2.ax1x.com/2019/02/03/kGPrY4.png)
![image](https://s2.ax1x.com/2019/02/03/kGP0TU.png)
![image](https://s2.ax1x.com/2019/02/03/kGPwwT.png)
![image](https://s2.ax1x.com/2019/02/03/kGP6p9.png)
![image](https://s2.ax1x.com/2019/02/03/kGPclR.png)