### PR TITLE
NpcScan设置页面可调整每页显示npc信息条目的最大数量

### DIFF
--- a/NpcScan/Info.json
+++ b/NpcScan/Info.json
@@ -2,7 +2,7 @@
   "Id": "NpcScan",
   "DisplayName": "NpcScan",
   "Author": "撒哈拉来的企鹅/沉浮山水/UnQ/inpayh",
-  "Version": "1.7.4",
+  "Version": "1.7.4.1",
   "AssemblyName": "NpcScan.dll",
   "EntryMethod": "NpcScan.Main.Load"
 }

--- a/NpcScan/NpcScan.cs
+++ b/NpcScan/NpcScan.cs
@@ -14,6 +14,8 @@ namespace NpcScan
             UnityModManager.ModSettings.Save<Settings>(this, modEntry);
         }
         public KeyCode key = KeyCode.F12;
+        // 每页最多显示的npc数目
+        public string countPerPage = "8";
     }
 
     public static class Main
@@ -88,6 +90,11 @@ namespace NpcScan
             {
                 UI.Load(modEntry);
                 UI.key = settings.key;
+                // 设置每页最多显示npc的数目
+                if(int.TryParse(settings.countPerPage, out int tmpValue) && tmpValue > 0)
+                {
+                    UI.Instance.countPerPage = tmpValue;
+                }
                 Main.uiIsShow = true;
                 //Logger.Log("scan测试");
             }
@@ -129,10 +136,30 @@ namespace NpcScan
             }
             GUILayout.Label("（支持0-9,A-Z,F1-F12）");
             GUILayout.EndHorizontal();
+            GUILayout.BeginHorizontal();
+
+            // 设置每页最多显示npc的数目
+            GUILayout.Label("每页最大显示NPC数量(范围1-50, 数字过大会影响游戏帧率)：",GUILayout.Width(370));
+            settings.countPerPage = GUILayout.TextField(settings.countPerPage, GUILayout.Width(40));
+            if (GUILayout.Button("确定",GUILayout.Width(40)))
+            {
+                if(int.TryParse(settings.countPerPage, out int tmpValue) && tmpValue > 0 && tmpValue < 50)
+                {
+                    UI.Instance.countPerPage = tmpValue;
+                }
+                else
+                {
+                    // 如果输入的不是正整数则恢复原值
+                    settings.countPerPage = UI.Instance.countPerPage.ToString();
+                }
+            }
+            GUILayout.EndHorizontal();
         }
 
         public static void OnSaveGUI(UnityModManager.ModEntry modEntry)
         {
+            // 退出时UMM时恢复countPerPage的值
+            settings.countPerPage = UI.Instance.countPerPage.ToString();
             settings.Save(modEntry);
         }
     }

--- a/NpcScan/UI.cs
+++ b/NpcScan/UI.cs
@@ -13,6 +13,7 @@ namespace NpcScan
     public class UI : MonoBehaviour
     {
         public static UnityModManager.ModEntry.ModLogger logger;
+        public int countPerPage = 8;
 
         private bool desc = true;
         private int sortIndex = 0;
@@ -151,7 +152,11 @@ namespace NpcScan
         private void Update()
         {
             if (mOpened)
+            {
                 mLogTimer += Time.unscaledDeltaTime;
+                // 自适应游戏窗口变化
+                mWindowRect.width = windowWidth();
+            }
             if ((Input.GetKey(KeyCode.RightControl) || Input.GetKey(KeyCode.LeftControl))
                 && Input.GetKeyUp(Main.settings.key))
             {
@@ -402,8 +407,8 @@ namespace NpcScan
                 scrollPosition = new Vector2(scrollPosition2.x, 0);
                 GUILayout.BeginVertical("box");
                 int c = mods.Count;
-                c = c > 50 * page ? 50 * page : c;
-                for (int i = (page - 1) * 50; i < c; i++)
+                c = c > countPerPage * page ? countPerPage * page : c;
+                for (int i = (page - 1) * countPerPage; i < c; i++)
                 {
                     GUILayout.BeginVertical("box");
                     GUILayout.BeginHorizontal();
@@ -515,7 +520,7 @@ namespace NpcScan
             #endregion
 
             #region add 翻页
-            GUILayout.Label(string.Format("{0}/{1}:", page, (int)Math.Ceiling((double)actorList.Count / 50d)), GUILayout.Width(40));
+            GUILayout.Label(string.Format("{0}/{1}:", page, (int)Math.Ceiling((double)actorList.Count / (double)countPerPage)), GUILayout.Width(40));
             if (GUILayout.Button("上页", GUILayout.Width(60)))
             {
                 if (page > 1)
@@ -530,7 +535,7 @@ namespace NpcScan
             }
             if (GUILayout.Button("下页", GUILayout.Width(60)))
             {
-                if (actorList.Count > page * 50)
+                if (actorList.Count > page * countPerPage)
                     page = page + 1;
             }
             #endregion


### PR DESCRIPTION
1. 每页显示50条npc信息非常影响游戏帧率，故将默认的每页显示数目调整为8，并在UMM中添加选项，可供调整每页显示npc信息条目的最大数量

2. 修正MOD搜索界面无法在游戏中自适应游戏窗口大小变化