### PR TITLE
修改CMakeLists.txt解决编译后部分mod不能编译问题和编译后文件不能拷贝的问题：

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,8 +325,8 @@ using System.Runtime.Versioning\;
 		${FILELIST}
 		${moddir}/Info.json
 		)
-	#项目版本 .net 4.6
-	set_property(TARGET ${moddir} PROPERTY VS_DOTNET_TARGET_FRAMEWORK_VERSION "v4.6")
+	#项目版本 .net 4.7.2
+	set_property(TARGET ${moddir} PROPERTY VS_DOTNET_TARGET_FRAMEWORK_VERSION "v4.7.2")
 	#项目基础引用
 	set_property(TARGET ${moddir} PROPERTY VS_DOTNET_REFERENCES
 		"System"
@@ -383,9 +383,9 @@ using System.Runtime.Versioning\;
 	#生成后事件，copy dll到游戏Mods目录
 	ADD_CUSTOM_COMMAND(TARGET ${moddir}
 		POST_BUILD
-		COMMAND if not exist "${STEAMDIR}\\Mods\\${moddir}/" echo not copy file & goto END
-		COMMAND copy \"$(TargetPATH)\" "${STEAMDIR}\\Mods\\${moddir}/"
-		COMMAND "..\\..\\CopyMod.exe" ${moddir} "${STEAMDIR}\\Mods"
+		COMMAND if not exist "\"${STEAMDIR}\"\\Mods\\${moddir}\\\"" echo not copy file & goto END
+		COMMAND copy "$(TargetPATH) \"${STEAMDIR}\\Mods\\${moddir}\\"
+		COMMAND "..\\..\\CopyMod.exe" ${moddir} "${STEAMDIR}\\Mods\\"
 		COMMAND echo "copy dll file ${moddir}.dll ok"
 		COMMENT "copy dll file to steam game"
 		COMMAND :END


### PR DESCRIPTION
1. 修改.net framework target为4.7.2以解决部分mod编译问题
2. copy命令和CopyMod.exe的路径参数里增加引号以应对${STEAMDIR}中含有空格的问题