### PR TITLE
修复战斗全赢

### DIFF
--- a/AllWin/AllWin.cs
+++ b/AllWin/AllWin.cs
@@ -63,7 +63,7 @@ namespace AllWin
     /// <summary>
     ///   // , new Type[] { typeof(bool), typeof(int) }
     /// </summary>
-    [HarmonyPatch(typeof(BattleSystem), "BattleEnd")]
+    [HarmonyPatch(typeof(BattleEndWindow), "BattleEnd")]
     public static class The_Patch
     {
 


### PR DESCRIPTION
fix "ArgumentException: No target method specified for class AllWin.The_Patch (declaringType=BattleSystem, methodName =BattleEnd, methodType=, argumentTypes=NULL)"