### PR TITLE
修正一处代码错误

### DIFF
--- a/CharacterFloatInfo/CharacterFloatInfo.cs
+++ b/CharacterFloatInfo/CharacterFloatInfo.cs
@@ -1629,8 +1629,7 @@ namespace CharacterFloatInfo
                 /// 品鉴等级 <seealso cref="ShopSystem.SetShopItems(int, int, int, int, int)"/>
                 int addlevel = DateFile.instance.GetActorValue(id, 506, true) * 3;
                 //商队
-                int typ = int.Parse(DateFile.instance.GetGangDate(int.Parse(DateFile.instance.GetActorDate(id, 9, false)), 16));
-                int shopTyp = int.Parse(DateFile.instance.GetGangDate(typ, 16));
+                int shopTyp = int.Parse(DateFile.instance.GetGangDate(int.Parse(DateFile.instance.GetActorDate(id, 9, false)), 16));
                 //商品等级Plus
                 int newShopLevel = DateFile.instance.storyShopLevel[shopTyp] + addlevel;
                 //好感等级


### PR DESCRIPTION
这处错误将0-6分别映射到0,1,0,4,2,0,3
这不会导致红字，但会让2-6商队的好感度与真实情况不对应
只有 服牛帮 和 文山书海阁 的映射正确。

代码产生了如下的错误好感度映射：

五湖商会 -> 服牛帮
大武魁商号 -> 回春堂
回春堂 -> 五湖商会
公输坊 -> 服牛帮
奇货斋 -> 大武魁商号